### PR TITLE
updated with tilde expansion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,4 +15,4 @@ Suggests:
 License: GPL-2
 SystemRequirements: phantomjs - http://phantomjs.org/
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rdom
 Title: Access the DOM of a webpage as HTML using phantomjs
-Version: 0.0.3.9000
+Version: 0.0.3.9001
 Authors@R: c(
   person("Carson", "Sievert", role = c("aut", "cre"), email = "cpsievert1@gmail.com"),
   person("Winston", "Chang", role = "cph", email = "winston@rstudio.com"))

--- a/R/rdom.R
+++ b/R/rdom.R
@@ -15,12 +15,19 @@
 #' @importFrom XML getNodeSet
 #'
 #' @examples \dontrun{
+#' filename = tempfile(tmpdir = "~", fileext = ".html") # added space
+#' rdom("https://en.wikipedia.org/wiki/Main_Page", filename = filename)
+#' rdom(filename)
+#' unlink(filename)
+#'
 #' library("rvest")
 #' stars <- "http://www.techstars.com/companies/stats/"
 #' # doesn't work
 #' html(stars) %>% html_node(".table75") %>% html_table()
 #' # should work
-#' rdom(stars) %>% html_node(".table75") %>% html_table()
+#' rdom(stars) %>%
+#' html_node(".table75") %>%
+#' html_table()
 #' # more efficient
 #' stars %>% rdom(".table75") %>% html_table()
 #' }
@@ -28,6 +35,12 @@
 
 rdom <- function(url, css, all, timeout, filename) {
   if (missing(url)) stop('Please specify a url.')
+  if (file.exists(url)) {
+    url = normalizePath(url)
+  }
+  if (!missing(filename)) {
+    filename = path.expand(filename)
+  }
   args <- list(
     system.file('rdomjs/rdom.js', package = 'rdom'),
     url,

--- a/man/rdom.Rd
+++ b/man/rdom.Rd
@@ -26,12 +26,19 @@ Return DOM of a website as HTML
 }
 \examples{
 \dontrun{
+filename = tempfile(tmpdir = "~", fileext = ".html") # added space
+rdom("https://en.wikipedia.org/wiki/Main_Page", filename = filename)
+rdom(filename)
+unlink(filename)
+
 library("rvest")
 stars <- "http://www.techstars.com/companies/stats/"
 # doesn't work
 html(stars) \%>\% html_node(".table75") \%>\% html_table()
 # should work
-rdom(stars) \%>\% html_node(".table75") \%>\% html_table()
+rdom(stars) \%>\%
+html_node(".table75") \%>\%
+html_table()
 # more efficient
 stars \%>\% rdom(".table75") \%>\% html_table()
 }


### PR DESCRIPTION
When the filename has a `~` in it, `rdom` now works:

``` r
library(rdom)
filename = tempfile(tmpdir = "~", fileext = ".html") # added space
x = rdom("https://en.wikipedia.org/wiki/Main_Page", filename = filename)
x = rdom(filename)
unlink(filename)
sessioninfo::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.6.0 (2019-04-26)
#>  os       macOS Mojave 10.14.5        
#>  system   x86_64, darwin15.6.0        
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       America/New_York            
#>  date     2019-07-31                  
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  package     * version    date       lib source                           
#>  assertthat    0.2.1      2019-03-21 [1] CRAN (R 3.6.0)                   
#>  cli           1.1.0      2019-03-19 [1] CRAN (R 3.6.0)                   
#>  crayon        1.3.4      2017-09-16 [1] CRAN (R 3.6.0)                   
#>  digest        0.6.20     2019-07-04 [1] CRAN (R 3.6.0)                   
#>  evaluate      0.14       2019-05-28 [1] CRAN (R 3.6.0)                   
#>  highr         0.8        2019-03-20 [1] CRAN (R 3.6.0)                   
#>  htmltools     0.3.6      2017-04-28 [1] CRAN (R 3.6.0)                   
#>  jsonlite      1.6        2018-12-07 [1] CRAN (R 3.6.0)                   
#>  knitr         1.23       2019-05-18 [1] CRAN (R 3.6.0)                   
#>  magrittr      1.5        2014-11-22 [1] CRAN (R 3.6.0)                   
#>  Rcpp          1.0.1      2019-03-17 [1] CRAN (R 3.6.0)                   
#>  rdom        * 0.0.3.9001 2019-07-31 [1] Github (muschellij2/rdom@5e663a8)
#>  rmarkdown     1.13       2019-05-22 [1] CRAN (R 3.6.0)                   
#>  sessioninfo   1.1.1      2018-11-05 [1] CRAN (R 3.6.0)                   
#>  stringi       1.4.3      2019-03-12 [1] CRAN (R 3.6.0)                   
#>  stringr       1.4.0      2019-02-10 [1] CRAN (R 3.6.0)                   
#>  withr         2.1.2      2018-03-15 [1] CRAN (R 3.6.0)                   
#>  xfun          0.8        2019-06-25 [1] CRAN (R 3.6.0)                   
#>  XML           3.98-1.20  2019-06-06 [1] CRAN (R 3.6.0)                   
#>  yaml          2.2.0      2018-07-25 [1] CRAN (R 3.6.0)                   
#> 
#> [1] /Library/Frameworks/R.framework/Versions/3.6/Resources/library
```

<sup>Created on 2019-07-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>